### PR TITLE
DCC-135 - Fix for missing sections that have been added but not appearing

### DIFF
--- a/app/javascript/src/orgAdmin/phases/newEdit.js
+++ b/app/javascript/src/orgAdmin/phases/newEdit.js
@@ -150,9 +150,9 @@ $(() => {
   });
 
   // Handle the section that has focus on initial page load
-  const currentSection = $('.section-group .in');
-  if (currentSection.length > 0) {
-    initSection(`${currentSection.attr('id')}`);
+  const currentUpdatedSection = $('.accordion-collapse.collapse.show');
+  if (currentUpdatedSection.length > 0) {
+    initSection(`${currentUpdatedSection.attr('id')}`);
   }
   // Handle the new section
   // initSection('#new_section_section_description');

--- a/app/views/org_admin/sections/_form.html.erb
+++ b/app/views/org_admin/sections/_form.html.erb
@@ -9,7 +9,7 @@
   <div class="form-group mb-3 col-md-10" data-toggle="tooltip" title="<%= description_tooltip %>">
     <em class="sr-only"><%= description_tooltip %></em>
     <%= f.label(:description, _('Description'), class: "control-label") %>
-    <%= f.text_area(:description, class: "section") %>
+    <%= f.text_area(:description, class: "section", spellcheck: true) %>
   </div>
 
   <div class="form-group mb-3 col-md-10">

--- a/app/views/org_admin/sections/_index.html.erb
+++ b/app/views/org_admin/sections/_index.html.erb
@@ -32,6 +32,16 @@
                                panel_id: "baseline-sections",
                                modifiable: modifiable } %>
       <% end %>
+         <% suffix_sections.each do |s| %>
+        <%= render partial: "org_admin/sections/section_group",
+                   locals: { sections: Array(s),
+                             phase: phase,
+                             template: template,
+                             panel_id: "section-#{s.id}",
+                             current_section: current_section,
+                             modifiable: true } %>
+      <% end %>
+      </div>
       <%# locals modifiable %>
       <!-- Accordion for sections -->
       <div class="row">


### PR DESCRIPTION
in Org Admin template customisation phase edit for modification. 

Also fixed a textArea for Section description that did not have TinyMCE editor attached.


