### PR TITLE
Dcc 4 migrating api servers table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,13 @@ yarn-debug.log*
 
 # Ignore briley AWS cloud9 script to start the application
 cloud9-start.sh
+
+# Ignore customisation files that do not have a roadmap counterpart
+app/assets/fonts/Cabin-Regular.ttf
+app/assets/images/powered_by_DMP_grey.png
+app/controllers/frih_service_controller.rb
+app/controllers/research_fi_service_controller.rb
+app/javascript/src/plans/call_frih_service.js
+app/javascript/src/plans/call_research_fi_service.js
+app/config/initializers/external_apis/frih.rb
+config/initializers/external_apis/research_fi.rb

--- a/.gitignore
+++ b/.gitignore
@@ -120,11 +120,10 @@ yarn-debug.log*
 cloud9-start.sh
 
 # Ignore customisation files that do not have a roadmap counterpart
+# general 
 app/assets/fonts/Cabin-Regular.ttf
 app/assets/images/powered_by_DMP_grey.png
-app/controllers/frih_service_controller.rb
+# dmptuuli-research.fi interoperation
 app/controllers/research_fi_service_controller.rb
-app/javascript/src/plans/call_frih_service.js
 app/javascript/src/plans/call_research_fi_service.js
-app/config/initializers/external_apis/frih.rb
 config/initializers/external_apis/research_fi.rb

--- a/app/models/api_server.rb
+++ b/app/models/api_server.rb
@@ -1,2 +1,4 @@
 class ApiServer < ApplicationRecord
+  validates :title, :description, presence: true
+  has_many :templates
 end

--- a/app/models/api_server.rb
+++ b/app/models/api_server.rb
@@ -1,0 +1,2 @@
+class ApiServer < ApplicationRecord
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -69,7 +69,7 @@ class Template < ApplicationRecord
 
   belongs_to :org
 
-  belongs_to :api_server
+  belongs_to :api_server, optional: true
 
   has_many :plans
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -69,6 +69,8 @@ class Template < ApplicationRecord
 
   belongs_to :org
 
+  belongs_to :api_server
+
   has_many :plans
 
   has_many :phases, dependent: :destroy

--- a/db/migrate/20240128230247_create_api_servers.rb
+++ b/db/migrate/20240128230247_create_api_servers.rb
@@ -1,0 +1,12 @@
+class CreateApiServers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_servers do |t|
+      t.string :title
+      t.string :description
+      t.string :client_id
+      t.string :client_secret
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240128230247_create_api_servers.rb
+++ b/db/migrate/20240128230247_create_api_servers.rb
@@ -3,8 +3,6 @@ class CreateApiServers < ActiveRecord::Migration[6.1]
     create_table :api_servers do |t|
       t.string :title
       t.string :description
-      t.string :client_id
-      t.string :client_secret
 
       t.timestamps
     end

--- a/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
+++ b/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
@@ -1,0 +1,5 @@
+class AddApiServerReferenceToTemplates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :templates, :api_servers, :foreign_key
+  end
+end

--- a/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
+++ b/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
@@ -1,5 +1,5 @@
 class AddApiServerReferenceToTemplates < ActiveRecord::Migration[6.1]
   def change
-    add_column :templates, :api_servers, :foreign_key
+    add_reference :templates, :api_servers, foreign_key: true
   end
 end

--- a/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
+++ b/db/migrate/20240128233752_add_api_server_reference_to_templates.rb
@@ -1,5 +1,5 @@
 class AddApiServerReferenceToTemplates < ActiveRecord::Migration[6.1]
   def change
-    add_reference :templates, :api_servers, foreign_key: true
+    add_reference :templates, :api_server, foreign_key: true
   end
 end

--- a/db/migrate/20240130000333_rename_api_servers_id_to_api_server_if_in_templates.rb
+++ b/db/migrate/20240130000333_rename_api_servers_id_to_api_server_if_in_templates.rb
@@ -1,0 +1,5 @@
+class RenameApiServersIdToApiServerIfInTemplates < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :templates, :api_servers_id, :api_server_id
+  end
+end

--- a/db/migrate/20240130000333_rename_api_servers_id_to_api_server_if_in_templates.rb
+++ b/db/migrate/20240130000333_rename_api_servers_id_to_api_server_if_in_templates.rb
@@ -1,5 +1,0 @@
-class RenameApiServersIdToApiServerIfInTemplates < ActiveRecord::Migration[6.1]
-  def change
-    rename_column :templates, :api_servers_id, :api_server_id
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,17 +2,20 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_104737) do
+ActiveRecord::Schema.define(version: 2024_01_28_233752) do
 
-  create_table "annotations", id: :integer, force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "annotations", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.integer "org_id"
     t.text "text"
@@ -20,12 +23,11 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "versionable_id", limit: 36
-    t.index ["org_id"], name: "fk_rails_aca7521f72"
     t.index ["question_id"], name: "index_annotations_on_question_id"
     t.index ["versionable_id"], name: "index_annotations_on_versionable_id"
   end
 
-  create_table "answers", id: :integer, force: :cascade do |t|
+  create_table "answers", id: :serial, force: :cascade do |t|
     t.text "text"
     t.integer "plan_id"
     t.integer "user_id"
@@ -33,11 +35,8 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "lock_version", default: 0
-    t.index ["plan_id"], name: "fk_rails_84a6005a3e"
     t.index ["plan_id"], name: "index_answers_on_plan_id"
-    t.index ["question_id"], name: "fk_rails_3d5ed4418f"
     t.index ["question_id"], name: "index_answers_on_question_id"
-    t.index ["user_id"], name: "fk_rails_584be190c2"
   end
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
@@ -46,28 +45,31 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["answer_id"], name: "index_answers_question_options_on_answer_id"
   end
 
-  create_table "api_clients", id: :integer, force: :cascade do |t|
+  create_table "api_clients", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.string "homepage"
     t.string "contact_name"
-    t.string "contact_email"
+    t.string "contact_email", null: false
     t.string "client_id", null: false
     t.string "client_secret", null: false
     t.datetime "last_access"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "org_id"
-    t.text "redirect_uri"
-    t.string "scopes", default: "", null: false
-    t.boolean "confidential", default: true
-    t.boolean "trusted", default: false
-    t.integer "callback_method"
-    t.string "callback_uri"
-    t.index ["name"], name: "index_oauth_applications_on_name"
+    t.index ["name"], name: "index_api_clients_on_name"
   end
 
-  create_table "conditions", id: :integer, force: :cascade do |t|
+  create_table "api_servers", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.string "client_id"
+    t.string "client_secret"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "conditions", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.text "option_list"
     t.integer "action_type"
@@ -79,7 +81,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["question_id"], name: "index_conditions_on_question_id"
   end
 
-  create_table "contributors", id: :integer, force: :cascade do |t|
+  create_table "contributors", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.string "phone"
@@ -89,13 +91,12 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["email"], name: "index_contributors_on_email"
-    t.index ["name", "id", "org_id"], name: "index_contrib_id_and_org_id"
     t.index ["org_id"], name: "index_contributors_on_org_id"
     t.index ["plan_id"], name: "index_contributors_on_plan_id"
     t.index ["roles"], name: "index_contributors_on_roles"
   end
 
-  create_table "departments", id: :integer, force: :cascade do |t|
+  create_table "departments", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.integer "org_id"
@@ -104,7 +105,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["org_id"], name: "index_departments_on_org_id"
   end
 
-  create_table "exported_plans", id: :integer, force: :cascade do |t|
+  create_table "exported_plans", id: :serial, force: :cascade do |t|
     t.integer "plan_id"
     t.integer "user_id"
     t.string "format"
@@ -113,22 +114,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "phase_id"
   end
 
-  create_table "external_api_access_tokens", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "external_service_name", null: false
-    t.string "access_token", null: false
-    t.string "refresh_token"
-    t.datetime "expires_at"
-    t.datetime "revoked_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["expires_at"], name: "index_external_api_access_tokens_on_expires_at"
-    t.index ["external_service_name"], name: "index_external_api_access_tokens_on_external_service_name"
-    t.index ["user_id", "external_service_name"], name: "index_external_tokens_on_user_and_service"
-    t.index ["user_id"], name: "index_external_api_access_tokens_on_user_id"
-  end
-
-  create_table "guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "guidance_groups", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "org_id"
     t.datetime "created_at", null: false
@@ -138,7 +124,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["org_id"], name: "index_guidance_groups_on_org_id"
   end
 
-  create_table "guidances", id: :integer, force: :cascade do |t|
+  create_table "guidances", id: :serial, force: :cascade do |t|
     t.text "text"
     t.integer "guidance_group_id"
     t.datetime "created_at", null: false
@@ -147,19 +133,18 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
   end
 
-  create_table "identifier_schemes", id: :integer, force: :cascade do |t|
+  create_table "identifier_schemes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "logo_url"
-    t.string "identifier_prefix"
+    t.text "logo_url"
+    t.text "identifier_prefix"
     t.integer "context"
-    t.string "external_service"
   end
 
-  create_table "identifiers", id: :integer, force: :cascade do |t|
+  create_table "identifiers", id: :serial, force: :cascade do |t|
     t.string "value", null: false
     t.text "attrs"
     t.integer "identifier_scheme_id"
@@ -172,7 +157,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["identifier_scheme_id", "value"], name: "index_identifiers_on_identifier_scheme_id_and_value"
   end
 
-  create_table "languages", id: :integer, force: :cascade do |t|
+  create_table "languages", id: :serial, force: :cascade do |t|
     t.string "abbreviation"
     t.string "description"
     t.string "name"
@@ -210,7 +195,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["research_output_id"], name: "metadata_research_outputs_on_ro"
   end
 
-  create_table "notes", id: :integer, force: :cascade do |t|
+  create_table "notes", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.text "text"
     t.boolean "archived", default: false, null: false
@@ -219,10 +204,9 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["answer_id"], name: "index_notes_on_answer_id"
-    t.index ["user_id"], name: "fk_rails_7f2323ad43"
   end
 
-  create_table "notification_acknowledgements", id: :integer, force: :cascade do |t|
+  create_table "notification_acknowledgements", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "notification_id"
     t.datetime "created_at"
@@ -231,7 +215,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id"], name: "index_notification_acknowledgements_on_user_id"
   end
 
-  create_table "notifications", id: :integer, force: :cascade do |t|
+  create_table "notifications", id: :serial, force: :cascade do |t|
     t.integer "notification_type"
     t.string "title"
     t.integer "level"
@@ -244,16 +228,15 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.boolean "enabled", default: true
   end
 
-  create_table "org_token_permissions", id: :integer, force: :cascade do |t|
+  create_table "org_token_permissions", id: :serial, force: :cascade do |t|
     t.integer "org_id"
     t.integer "token_permission_type_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["org_id"], name: "index_org_token_permissions_on_org_id"
-    t.index ["token_permission_type_id"], name: "fk_rails_2aa265f538"
   end
 
-  create_table "orgs", id: :integer, force: :cascade do |t|
+  create_table "orgs", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "abbreviation"
     t.string "target_url"
@@ -267,24 +250,20 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.string "contact_email"
     t.integer "org_type", default: 0, null: false
     t.text "links"
+    t.string "contact_name"
     t.boolean "feedback_enabled", default: false
     t.text "feedback_msg"
-    t.string "contact_name"
     t.boolean "managed", default: false, null: false
-    t.string "api_create_plan_email_subject"
-    t.text "api_create_plan_email_body"
-    t.index ["language_id"], name: "fk_rails_5640112cab"
-    t.index ["region_id"], name: "fk_rails_5a6adf6bab"
     t.string "helpdesk_email"
   end
 
-  create_table "perms", id: :integer, force: :cascade do |t|
+  create_table "perms", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "phases", id: :integer, force: :cascade do |t|
+  create_table "phases", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "number"
@@ -297,7 +276,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_phases_on_versionable_id"
   end
 
-  create_table "plans", id: :integer, force: :cascade do |t|
+  create_table "plans", id: :serial, force: :cascade do |t|
     t.string "title"
     t.integer "template_id"
     t.datetime "created_at"
@@ -310,45 +289,32 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "org_id"
     t.integer "funder_id"
     t.integer "grant_id"
-    t.integer "api_client_id"
     t.datetime "start_date"
     t.datetime "end_date"
+    t.bigint "research_domain_id"
     t.boolean "ethical_issues"
     t.text "ethical_issues_description"
     t.string "ethical_issues_report"
     t.integer "funding_status"
-    t.bigint "research_domain_id"
     t.index ["funder_id"], name: "index_plans_on_funder_id"
     t.index ["grant_id"], name: "index_plans_on_grant_id"
     t.index ["org_id"], name: "index_plans_on_org_id"
-    t.index ["research_domain_id"], name: "index_plans_on_fos_id"
+    t.index ["research_domain_id"], name: "index_plans_on_research_domain_id"
     t.index ["template_id"], name: "index_plans_on_template_id"
-    t.index ["api_client_id"], name: "index_plans_on_api_client_id"
   end
 
-  create_table "plans_guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "plans_guidance_groups", id: :serial, force: :cascade do |t|
     t.integer "guidance_group_id"
     t.integer "plan_id"
     t.index ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id"
-    t.index ["guidance_group_id"], name: "fk_rails_ec1c5524d7"
-    t.index ["plan_id"], name: "fk_rails_13d0671430"
   end
 
-  create_table "prefs", id: :integer, force: :cascade do |t|
+  create_table "prefs", id: :serial, force: :cascade do |t|
     t.text "settings"
     t.integer "user_id"
   end
 
-  create_table "question_format_labels", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.string "description"
-    t.integer "question_id"
-    t.integer "number"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "question_formats", id: :integer, force: :cascade do |t|
+  create_table "question_formats", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -357,7 +323,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "formattype", default: 0
   end
 
-  create_table "question_options", id: :integer, force: :cascade do |t|
+  create_table "question_options", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.string "text"
     t.integer "number"
@@ -369,7 +335,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_question_options_on_versionable_id"
   end
 
-  create_table "questions", id: :integer, force: :cascade do |t|
+  create_table "questions", id: :serial, force: :cascade do |t|
     t.text "text"
     t.text "default_value"
     t.integer "number"
@@ -380,7 +346,6 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.boolean "option_comment_display", default: true
     t.boolean "modifiable"
     t.string "versionable_id", limit: 36
-    t.index ["question_format_id"], name: "fk_rails_4fbc38c8c7"
     t.index ["section_id"], name: "index_questions_on_section_id"
     t.index ["versionable_id"], name: "index_questions_on_versionable_id"
   end
@@ -391,26 +356,11 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["question_id"], name: "index_questions_themes_on_question_id"
   end
 
-  create_table "regions", id: :integer, force: :cascade do |t|
+  create_table "regions", id: :serial, force: :cascade do |t|
     t.string "abbreviation"
     t.string "description"
     t.string "name"
     t.integer "super_region_id"
-  end
-
-  create_table "related_identifiers", force: :cascade do |t|
-    t.bigint "identifier_scheme_id"
-    t.integer "identifier_type", null: false
-    t.integer "relation_type", null: false
-    t.bigint "identifiable_id"
-    t.string "identifiable_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "value", null: false
-    t.index ["identifiable_id", "identifiable_type", "relation_type"], name: "index_relateds_on_identifiable_and_relation_type"
-    t.index ["identifier_scheme_id"], name: "index_related_identifiers_on_identifier_scheme_id"
-    t.index ["identifier_type"], name: "index_related_identifiers_on_identifier_type"
-    t.index ["relation_type"], name: "index_related_identifiers_on_relation_type"
   end
 
   create_table "repositories", force: :cascade do |t|
@@ -465,7 +415,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["plan_id"], name: "index_research_outputs_on_plan_id"
   end
 
-  create_table "roles", id: :integer, force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "plan_id"
     t.datetime "created_at"
@@ -476,7 +426,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id"], name: "index_roles_on_user_id"
   end
 
-  create_table "sections", id: :integer, force: :cascade do |t|
+  create_table "sections", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "number"
@@ -489,7 +439,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_sections_on_versionable_id"
   end
 
-  create_table "sessions", id: :integer, force: :cascade do |t|
+  create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", limit: 64, null: false
     t.text "data"
     t.datetime "created_at"
@@ -498,16 +448,16 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", id: :integer, force: :cascade do |t|
-    t.string "var"
+  create_table "settings", id: :serial, force: :cascade do |t|
+    t.string "var", null: false
     t.text "value"
     t.integer "target_id", null: false
-    t.string "target_type"
+    t.string "target_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "stats", id: :integer, force: :cascade do |t|
+  create_table "stats", id: :serial, force: :cascade do |t|
     t.bigint "count", default: 0
     t.date "date", null: false
     t.string "type", null: false
@@ -518,20 +468,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.boolean "filtered", default: false
   end
 
-  create_table "subscriptions", force: :cascade do |t|
-    t.bigint "plan_id"
-    t.integer "subscription_types", null: false
-    t.string "callback_uri"
-    t.bigint "subscriber_id"
-    t.string "subscriber_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "last_notified"
-    t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
-    t.index ["subscriber_id", "subscriber_type", "plan_id"], name: "index_subscribers_on_identifiable_and_plan_id"
-  end
-
-  create_table "templates", id: :integer, force: :cascade do |t|
+  create_table "templates", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.boolean "published"
@@ -546,13 +483,15 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "family_id"
     t.boolean "archived"
     t.text "links"
+    t.bigint "api_servers_id"
+    t.index ["api_servers_id"], name: "index_templates_on_api_servers_id"
     t.index ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
     t.index ["family_id"], name: "index_templates_on_family_id"
     t.index ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
     t.index ["org_id"], name: "index_templates_on_org_id"
   end
 
-  create_table "themes", id: :integer, force: :cascade do |t|
+  create_table "themes", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -567,14 +506,14 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["theme_id"], name: "index_themes_in_guidance_on_theme_id"
   end
 
-  create_table "token_permission_types", id: :integer, force: :cascade do |t|
+  create_table "token_permission_types", id: :serial, force: :cascade do |t|
     t.string "token_type"
     t.text "text_description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "trackers", id: :integer, force: :cascade do |t|
+  create_table "trackers", id: :serial, force: :cascade do |t|
     t.integer "org_id"
     t.string "code"
     t.datetime "created_at", null: false
@@ -582,13 +521,13 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["org_id"], name: "index_trackers_on_org_id"
   end
 
-  create_table "users", id: :integer, force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "firstname"
     t.string "surname"
     t.string "email", limit: 80, default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: ""
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -612,21 +551,16 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.string "invited_by_type"
     t.integer "language_id"
     t.string "recovery_email"
-    t.string "ldap_password"
-    t.string "ldap_username"
     t.boolean "active", default: true
     t.integer "department_id"
     t.datetime "last_api_access"
-    t.index ["department_id"], name: "fk_rails_f29bf9cdf2"
-    t.index ["email"], name: "index_users_on_email"
-    t.index ["language_id"], name: "fk_rails_45f4f12508"
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["org_id"], name: "index_users_on_org_id"
   end
 
   create_table "users_perms", id: false, force: :cascade do |t|
     t.integer "user_id"
     t.integer "perm_id"
-    t.index ["perm_id"], name: "fk_rails_457217c31c"
     t.index ["user_id"], name: "index_users_perms_on_user_id"
   end
 
@@ -634,12 +568,12 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
   add_foreign_key "annotations", "questions"
   add_foreign_key "answers", "plans"
   add_foreign_key "answers", "questions"
-  add_foreign_key "answers", "users"
+  add_foreign_key "answers_question_options", "answers"
+  add_foreign_key "answers_question_options", "question_options"
   add_foreign_key "conditions", "questions"
   add_foreign_key "guidance_groups", "orgs"
   add_foreign_key "guidances", "guidance_groups"
   add_foreign_key "notes", "answers"
-  add_foreign_key "notes", "users"
   add_foreign_key "notification_acknowledgements", "notifications"
   add_foreign_key "notification_acknowledgements", "users"
   add_foreign_key "org_token_permissions", "orgs"
@@ -654,11 +588,13 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
   add_foreign_key "question_options", "questions"
   add_foreign_key "questions", "question_formats"
   add_foreign_key "questions", "sections"
+  add_foreign_key "questions_themes", "questions"
+  add_foreign_key "questions_themes", "themes"
   add_foreign_key "research_domains", "research_domains", column: "parent_id"
   add_foreign_key "research_outputs", "licenses"
   add_foreign_key "roles", "plans"
-  add_foreign_key "roles", "users"
   add_foreign_key "sections", "phases"
+  add_foreign_key "templates", "api_servers", column: "api_servers_id"
   add_foreign_key "templates", "orgs"
   add_foreign_key "themes_in_guidance", "guidances"
   add_foreign_key "themes_in_guidance", "themes"
@@ -666,4 +602,6 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
   add_foreign_key "users", "departments"
   add_foreign_key "users", "languages"
   add_foreign_key "users", "orgs"
+  add_foreign_key "users_perms", "perms"
+  add_foreign_key "users_perms", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_28_233752) do
+ActiveRecord::Schema.define(version: 2024_01_30_000333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -483,8 +483,8 @@ ActiveRecord::Schema.define(version: 2024_01_28_233752) do
     t.integer "family_id"
     t.boolean "archived"
     t.text "links"
-    t.bigint "api_servers_id"
-    t.index ["api_servers_id"], name: "index_templates_on_api_servers_id"
+    t.bigint "api_server_id"
+    t.index ["api_server_id"], name: "index_templates_on_api_server_id"
     t.index ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
     t.index ["family_id"], name: "index_templates_on_family_id"
     t.index ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
@@ -594,7 +594,7 @@ ActiveRecord::Schema.define(version: 2024_01_28_233752) do
   add_foreign_key "research_outputs", "licenses"
   add_foreign_key "roles", "plans"
   add_foreign_key "sections", "phases"
-  add_foreign_key "templates", "api_servers", column: "api_servers_id"
+  add_foreign_key "templates", "api_servers"
   add_foreign_key "templates", "orgs"
   add_foreign_key "themes_in_guidance", "guidances"
   add_foreign_key "themes_in_guidance", "themes"


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- This PR has a migration of the api_servers table, which includes a foreign key referring to the api_server column of the templates table. 
- This is required as part of the machine-actionable grant-id feature for the DMPTuuli service. 
- However, the actual UI of the feature is implemented as a customisation at the dmp_tuuli_setup code.
- This PR also includes additions to the .gitignore file so that customisation files that have no counterpart in roadmap are ignored by git.